### PR TITLE
fix: tencent serverless output get bug workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ```js
 window.env = {
-  API_URL: '/'
+  API_DETAILS: [{ urls: ['/'] }]
 }
 ```
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,5 +14,7 @@ inputs:
   replace: true
   protocol: https
   env:
-    API_URL: ${output:${stage}:${app}:pkuphysu-wechat.triggers[0].urls[0]}
+    # Tencent doesn't support `triggers[0]` yet.
+    # It just doesn't get replaced
+    API_DETAILS: ${output:${stage}:${app}:pkuphysu-wechat.triggers}
     APPID: ${env:APPID}

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,4 +1,6 @@
 export const requestApi = async (method, url, data) => {
+  const API_URL = window.env.API_DETAILS[0].urls[0]
+
   const fetchInit = {
     headers: new Headers(),
     method,
@@ -12,7 +14,7 @@ export const requestApi = async (method, url, data) => {
   if (data) {
     fetchInit.headers.append('Content-Type', 'application/json')
   }
-  return fetch(new URL(url, window.env.API_URL), fetchInit)
+  return fetch(new URL(url, API_URL), fetchInit)
     .then(resp => resp.json())
     .catch(err => alert(err))
 }


### PR DESCRIPTION
如果是原来这样，最后 `env.js` 里就是

```js
API_URL: '${output:${stage}:${app}:pkuphysu-wechat.triggers[0].urls[0]}'
```

原样没有被替换。

注意这不是因为打错了，如果真打错了会报

```
The referenced output "${output:dev:pkuphysu-wechat:pkuphysu-wechat.triggers.0.url}" was not found
```

也就是说在腾讯的服务器上找到了 output，但是该 output 没有被替换（可能是腾讯返回了错误的或者空的 output）