### PR TITLE
chore: migrate from sls to scf

### DIFF
--- a/.github/workflows/sls-deploy.yml
+++ b/.github/workflows/sls-deploy.yml
@@ -37,16 +37,15 @@ jobs:
           APPID_PROD: ${{ secrets.APPID_PROD }}
           APPID_DEV: ${{ secrets.APPID_DEV }}
       - name: Install serverless
-        run: curl -o- -L https://slss.io/install | bash
+        run: npm install -g serverless-cloud-framework
       - name: Deploy serverless website
         timeout-minutes: 5
         run: |
           set -o pipefail
-          $HOME/.serverless/bin/sls deploy | grep -v -e '中 ' -e '化 ' -e NA
+          scf deploy | grep -v -e '中 ' -e '化 ' -e NA
         env:
           STAGE: ${{ steps.env.outputs.stage }}
           APPID: ${{ steps.env.outputs.appid }}
           SERVERLESS_PLATFORM_VENDOR: tencent
-          SLS_GEO_LOCATION: cn
           TENCENT_SECRET_ID: ${{ secrets.TENCENT_SECRET_ID }}
           TENCENT_SECRET_KEY: ${{ secrets.TENCENT_SECRET_KEY }}

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,5 +16,5 @@ inputs:
   env:
     # Tencent doesn't support `triggers[0]` yet.
     # It just doesn't get replaced
-    API_DETAILS: ${output:${stage}:${app}:pkuphysu-wechat.triggers}
+    API_URL: ${output:${stage}:${app}:pkuphysu-wechat.triggers.0.urls.0}
     APPID: ${env:APPID}

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,7 +1,7 @@
 export const requestApi = async (method, url, data) => {
   const requestUrl = import.meta.env.DEV
     ? new URL(`/__api${url.startsWith('/') ? url : `/${url}`}`, location.origin)
-    : new URL(url, window.env.API_DETAILS[0].urls[0])
+    : new URL(url, window.env.API_URL)
 
   const fetchInit = {
     headers: new Headers(),


### PR DESCRIPTION
现在`${output:${stage}:${app}:pkuphysu-wechat.triggers}`又不能用了，部署会直接报错，
需要用`${output:${stage}:${app}:pkuphysu-wechat.triggers.0.urls.0}`